### PR TITLE
Add GC logging to node-process-metrics

### DIFF
--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 kayvee = require 'kayvee'
+memwatch = require 'memwatch'
 
 env = process.env.NODE_ENV or 'staging'
 
@@ -58,3 +59,8 @@ module.exports.log_metrics = (source, frequency_ms, pause_threshold_ms = 1000) -
   start_pause_detector source, 100, pause_threshold_ms
   setInterval _.partial(log_pauses, source), frequency_ms
 
+  memwatch.on 'stats', (stats) ->
+    kayvee_logger.counterD 'gc-stats', 1, stats
+
+  memwatch.on 'leak', (info) ->
+    kayvee_logger.counterD 'gc-leak', 1, info

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "coffee-script": "~1.6.2",
     "kayvee": "^1.0.3",
+    "memwatch": "^0.2.2",
     "underscore": "~1.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Holding off on heap-dump/diff for now since that's more computationally
expensive