### PR TITLE
Upgrade to memwatch-next to work on Node 4+

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: node0.10
+image: clever/drone-node:6.2.2
 notify:
   email:
     recipients:
@@ -16,9 +16,6 @@ publish:
     when:
       branch: master
 script:
-- npm config set ca ""
 - npm install
 - npm test
-- nvm install 0.10.29
-- nvm use 0.10.29
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: clever/drone-node:6.2.2
+image: clever/drone-node:5.7.0
 notify:
   email:
     recipients:

--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -1,6 +1,6 @@
 _ = require 'underscore'
 kayvee = require 'kayvee'
-memwatch = require 'memwatch'
+memwatch = require 'memwatch-next'
 
 env = process.env.NODE_ENV or 'staging'
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "coffee-script": "~1.6.2",
     "kayvee": "^1.0.3",
-    "memwatch": "^0.2.2",
+    "memwatch-next": "^0.3.0",
     "underscore": "~1.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
It was failing to install when added to the package.json in a node 5 repo.

Based on
http://stackoverflow.com/questions/29058731/installing-node-memwatch-on-centos-6-node-gyp-rebuild-error