### PR TITLE
Add `make build` step to drone file.  How did this ever work?

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,3 +16,4 @@ publish:
 script:
 - npm install
 - make test
+- make build

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "engines": {
     "node": ">=0.10.x"
   },


### PR DESCRIPTION
Added `make build` to drone file.  Without it the `./lib-js` folder is never created which means nothing is uploaded to npm.  As far as I can tell this repo as been broken since ever it was converted to type script.  I hate type script.