### PR TITLE
Bump up test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepare": "tsc",
     "lint": "eslint",
-    "test": "mocha --require ts-node/register --exit test/*"
+    "test": "mocha --require ts-node/register --timeout 15000 --exit test/*"
   },
   "author": "Clever Team <tech-notify@clever.com>",
   "description": "process-metrics",


### PR DESCRIPTION
CI might fail to run the test to completion:

```
  1) Pause test
       should record a later time after event loop is blocked:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/circleci/Clever/node-process-metrics/test/metrics.ts)
```

On a development machine, this takes 1700~ ms. Let's bump up the
time so it doesn't timeout.